### PR TITLE
Use HTTPS for secure connection as per bundler.io/git.html

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -9,7 +9,7 @@ The list of currencies are provided by the {Money}[http://money.rubyforge.org/] 
 
 Add the following to your Gemfile
 
-gem 'currency_select', github: 'tanordheim/currency_select'
+gem 'currency_select', :git => 'https://github.com/tanordheim/currency_select.git'
 
 
 = Example


### PR DESCRIPTION
Per the 'Security' section in the Bundler docs, http://bundler.io/git.html, using the "github" shortcut is insecure. It is recommended to use HTTPS.
